### PR TITLE
Shutdown thread pool in ZipUtils.transferData

### DIFF
--- a/wss-agent-utils/src/main/java/org/whitesource/agent/utils/ZipUtils.java
+++ b/wss-agent-utils/src/main/java/org/whitesource/agent/utils/ZipUtils.java
@@ -318,15 +318,15 @@ public class ZipUtils {
 
     private static void transferData(Runnable producer, Runnable consumer) {
         ExecutorService threadPool = Executors.newFixedThreadPool(N_THREADS);
-        threadPool.submit(producer);
         try {
+            threadPool.submit(producer);
             threadPool.submit(consumer).get();
         } catch (InterruptedException e) {
             // logger.error("Task failed : ", e);
         } catch (ExecutionException e) {
             // logger.error("Task failed : ", e);
         } finally {
-            //  threadPool.shutdown();
+            threadPool.shutdown();
         }
     }
 


### PR DESCRIPTION
When running several updates in the same process the threads increase until new threads cannot be created.

Why was the `threadpool.shutdown()` call commented out?

I think a better approach is to use a static thread pool and increase N_THREADS. I can implement that if you'd like.