### PR TITLE
WSE-5636 add OSInfo to DependencyInfo

### DIFF
--- a/wss-agent-api/src/main/java/org/whitesource/agent/api/model/DependencyInfo.java
+++ b/wss-agent-api/src/main/java/org/whitesource/agent/api/model/DependencyInfo.java
@@ -72,6 +72,7 @@ public class DependencyInfo implements Serializable {
     private Map<String, String> dependencyModulesToPaths;
     private String euaArtifactId;
     private Collection<DependencyInfo> aggregatedDependencies;
+    private OSInfo osInfo;
 
     /* --- Constructors --- */
 
@@ -535,5 +536,13 @@ public class DependencyInfo implements Serializable {
 
     public void setAggregatedDependencies(Collection<DependencyInfo> aggregatedDependencies) {
         this.aggregatedDependencies = aggregatedDependencies;
+    }
+
+    public OSInfo getOsInfo() {
+        return osInfo;
+    }
+
+    public void setOsInfo(OSInfo osInfo) {
+        this.osInfo = osInfo;
     }
 }

--- a/wss-agent-api/src/main/java/org/whitesource/agent/api/model/OSInfo.java
+++ b/wss-agent-api/src/main/java/org/whitesource/agent/api/model/OSInfo.java
@@ -1,0 +1,29 @@
+package org.whitesource.agent.api.model;
+
+
+public class OSInfo {
+
+    /*
+     * examples:
+     *  ID=ubuntu + VERSION=20.04
+     *  ID=fedora + VERSION=33
+     */
+    private String id;
+    private String version;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}


### PR DESCRIPTION
add OSInfo object
add OSInfo to DependencyInfo

the info is in a separate object for:
1. save runtime memory, for only only relevant to Linux/Dockers
2. a wrapper object that might get additional information later on