### PR TITLE
fix release gpg

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,13 +46,6 @@ jobs:
           git config user.name "whitesource-ci"
           git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
 
-      - name: Configure GPG
-        run: |
-          mkdir -p ~/.gnupg
-          chmod 700 ~/.gnupg
-          echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
-          echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
-
       - name: Maven Release
         run: |
           export GPG_TTY=$(tty)

--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,27 @@
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>2.4.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.2.7</version>
+                    <configuration>
+                        <gpgArguments>
+                            <arg>--pinentry-mode</arg>
+                            <arg>loopback</arg>
+                        </gpgArguments>
+                        <bestPractices>true</bestPractices>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Add maven-gpg-plugin configuration to pom.xml for artifact signing during verify phase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled cryptographic signing of build artifacts to improve integrity and trust.
  * Applied the same signing configuration to CI builds for consistent verification.
  * Removed manual pre-configuration of GPG setup from the release workflow.
  * No changes to runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->