### PR TITLE
Bugfix: OutOfMemory issue cause by Rhino (3rd party library)

### DIFF
--- a/wss-agent-hash-calculator/pom.xml
+++ b/wss-agent-hash-calculator/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
-            <version>1.7.7.2</version>
+            <version>1.7.8</version>
         </dependency>
 
         <!-- Logging -->


### PR DESCRIPTION
Transitive library org.mozilla.rhino uses version 1.7.7.2 (used originally by reacability using unified-agent) has possible OutOfMemory due to infinite loop on parsing Issue Objects are only thread-safe when feature is enabled. (https://github.com/mozilla/rhino/blob/master/RELEASE-NOTES.md#rhino-178)

Using override to use version 1.7.8 fixes this issue.

Resolves: SCA-4120

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `org.mozilla:rhino` in `wss-agent-hash-calculator/pom.xml` from `1.7.7.2` to `1.7.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef57496b54f61b11803017791d19f7e8752cfcd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core library dependency for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->