### PR TITLE
Fix JavaScript header comment removal edge case

### DIFF
--- a/wss-agent-hash-calculator/src/main/java/org/whitesource/agent/parser/JavaScriptParser.java
+++ b/wss-agent-hash-calculator/src/main/java/org/whitesource/agent/parser/JavaScriptParser.java
@@ -1,6 +1,5 @@
 package org.whitesource.agent.parser;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ast.AstRoot;
@@ -71,20 +70,37 @@ public class JavaScriptParser {
      * Go over each comment and remove from content until reaching the beginning of the actual code.
      */
     private String removeHeaderComments(String fileContent, SortedSet<Comment> comments) {
-        String headerlessFileContent = fileContent;
+        int contentLength = fileContent.length();
+        int currentIndex = 0;
         for (Comment comment : comments) {
-            String commentValue = comment.getValue();
-            if (headerlessFileContent.startsWith(commentValue)) {
-                headerlessFileContent = headerlessFileContent.replace(commentValue, EMPTY_STRING);
-                // remove all leading white spaces and new line characters
-                while (StringUtils.isNotBlank(headerlessFileContent) && Character.isWhitespace(headerlessFileContent.charAt(0))) {
-                    headerlessFileContent = headerlessFileContent.substring(1);
-                }
-            } else {
+            int commentStart = comment.getAbsolutePosition();
+
+            if (commentStart > currentIndex) {
                 // finished removing all header comments
                 break;
             }
+
+            if (commentStart + comment.getLength() > contentLength) {
+                // safety check – malformed comment location
+                break;
+            }
+
+            if (commentStart < currentIndex) {
+                // comment already removed as part of a previous comment
+                continue;
+            }
+
+            currentIndex += comment.getLength();
+
+            while (currentIndex < contentLength && Character.isWhitespace(fileContent.charAt(currentIndex))) {
+                currentIndex++;
+            }
         }
-        return headerlessFileContent;
+
+        if (currentIndex >= contentLength) {
+            return EMPTY_STRING;
+        }
+
+        return fileContent.substring(currentIndex);
     }
 }

--- a/wss-agent-hash-calculator/src/test/java/org/whitesource/agent/hash/JavaScriptHashCalculatorTest.java
+++ b/wss-agent-hash-calculator/src/test/java/org/whitesource/agent/hash/JavaScriptHashCalculatorTest.java
@@ -60,6 +60,15 @@ public class JavaScriptHashCalculatorTest {
         assertTrue(commentlessContent.startsWith("(function(factory) {"));
     }
 
+    @Test
+    public void testRemoveHeaderCommentEndingWithP() {
+        String fileContent = "//# sourceMappingURL=IRotate.js.map";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        String headerlessContent = parseResult.getContentWithoutHeaderComments();
+        Assert.assertNotNull(headerlessContent);
+        Assert.assertEquals(0, headerlessContent.length());
+    }
+
 //    @Ignore
     @Test
     public void testCalculateJavaScriptHash() throws IOException, WssHashException {


### PR DESCRIPTION
## Summary
- adjust JavaScript header comment removal to use parser-provided comment positions instead of raw string replacement
- add a regression test covering header comments that end with the character `p`

## Testing
- mvn -pl wss-agent-hash-calculator test *(fails: cannot resolve org.sonatype.central:central-publishing-maven-plugin:0.9.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_68fa34768e6c83278ebc1d4235bddb3c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validation for header comment removal in JavaScript files.

* **Refactor**
  * Improved robustness of header comment removal logic with enhanced boundary checking and safety validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->