### PR TITLE
SCA-5117 fix hash-calculator bug causing source file mapping collision

### DIFF
--- a/wss-agent-hash-calculator/src/main/java/org/whitesource/agent/parser/JavaScriptParser.java
+++ b/wss-agent-hash-calculator/src/main/java/org/whitesource/agent/parser/JavaScriptParser.java
@@ -3,6 +3,7 @@ package org.whitesource.agent.parser;
 import org.apache.commons.lang3.StringUtils;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.Token;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.Comment;
 import org.slf4j.LoggerFactory;
@@ -23,7 +24,9 @@ public class JavaScriptParser {
 
     private static final String EMPTY_STRING = "";
 
-    private static final String COMMENT_REGEX = "(/\\*[\\s\\S]*?\\*/)";
+    private static final String LINE_COMMENT_PREFIX = "//";
+    private static final String HTML_OPEN_COMMENT_PREFIX = "<!--";
+    private static final String HTML_CLOSE_COMMENT_PREFIX = "-->";
 
     /* --- Public methods --- */
 
@@ -68,23 +71,69 @@ public class JavaScriptParser {
     /* --- Private methods --- */
 
     /**
-     * Go over each comment and remove from content until reaching the beginning of the actual code.
+     * Strip leading comments (and the whitespace between them) until reaching
+     * the first non-comment content.
+     *
+     * For line-style comments (LINE / HTML) we scan to the next line terminator
+     * rather than relying on {@link Comment#getValue()}: Rhino 1.7.7.2 returns
+     * a value that is one character short when the comment is not newline-
+     * terminated (e.g. at EOF), which would leak the trailing character of the
+     * file into the headerless content and produce hash collisions in the
+     * Index. See TKA-8744 / SCA-5117.
+     *
+     * For block-style comments (BLOCK / JSDOC) the closing &#42;/ delimiter is
+     * required to terminate the comment, so {@link Comment#getValue()} is
+     * reliable. Stripping is anchored at offset 0 ({@code substring}) instead
+     * of using {@code String.replace}, which would also strip later in-body
+     * occurrences of the same string.
      */
     private String removeHeaderComments(String fileContent, SortedSet<Comment> comments) {
         String headerlessFileContent = fileContent;
         for (Comment comment : comments) {
-            String commentValue = comment.getValue();
-            if (headerlessFileContent.startsWith(commentValue)) {
-                headerlessFileContent = headerlessFileContent.replace(commentValue, EMPTY_STRING);
-                // remove all leading white spaces and new line characters
-                while (StringUtils.isNotBlank(headerlessFileContent) && Character.isWhitespace(headerlessFileContent.charAt(0))) {
-                    headerlessFileContent = headerlessFileContent.substring(1);
-                }
-            } else {
-                // finished removing all header comments
+            String afterRemoval = removeLeadingHeader(headerlessFileContent, comment);
+            if (afterRemoval == null) {
+                // no longer at a header — body reached
                 break;
             }
+            headerlessFileContent = StringUtils.stripStart(afterRemoval, null);
         }
         return headerlessFileContent;
+    }
+
+    /**
+     * Returns the content with the given header comment removed from offset 0,
+     * or {@code null} if the content does not currently start with that
+     * comment (i.e. we've reached the body of the file).
+     */
+    private String removeLeadingHeader(String content, Comment comment) {
+        Token.CommentType type = comment.getCommentType();
+        if (type == Token.CommentType.LINE || type == Token.CommentType.HTML) {
+            if (!startsWithLineCommentDelimiter(content)) {
+                return null;
+            }
+            int terminatorIdx = indexOfLineTerminator(content);
+            return terminatorIdx < 0 ? EMPTY_STRING : content.substring(terminatorIdx);
+        }
+        String commentValue = comment.getValue();
+        if (!content.startsWith(commentValue)) {
+            return null;
+        }
+        return content.substring(commentValue.length());
+    }
+
+    private static boolean startsWithLineCommentDelimiter(String s) {
+        return s.startsWith(LINE_COMMENT_PREFIX)
+                || s.startsWith(HTML_OPEN_COMMENT_PREFIX)
+                || s.startsWith(HTML_CLOSE_COMMENT_PREFIX);
+    }
+
+    private static int indexOfLineTerminator(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\n' || c == '\r') {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/wss-agent-hash-calculator/src/test/java/org/whitesource/agent/parser/JavaScriptParserTest.java
+++ b/wss-agent-hash-calculator/src/test/java/org/whitesource/agent/parser/JavaScriptParserTest.java
@@ -1,0 +1,81 @@
+package org.whitesource.agent.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link JavaScriptParser#parse(String)}, focused on the
+ * {@code contentWithoutHeaderComments} output that feeds the
+ * {@code SHA1_NO_HEADER} checksum.
+ * <p>
+ * Reproduces TKA-8744 / SCA-5117: pseudo-elements.js (and any single-line
+ * header comment with no trailing newline) was producing a stray
+ * trailing character in the headerless content, causing hash collisions in
+ * the Index (e.g. with pnotify.tooltip-2.0.0.js).
+ */
+public class JavaScriptParserTest {
+
+    @Test
+    public void headerCommentEndingWithP_isFullyStripped() {
+        String fileContent = "//# sourceMappingURL=IRotate.js.map";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        String headerlessContent = parseResult.getContentWithoutHeaderComments();
+        Assert.assertNotNull(headerlessContent);
+        Assert.assertEquals(0, headerlessContent.length());
+    }
+
+    @Test
+    public void lineCommentEndingInArbitraryChar_isFullyStripped() {
+        // The Rhino EOF bug truncates the comment value by one char regardless
+        // of which character is last; "Tooltip" ends in 'p' and was the
+        // observed collision driver, but the fix must work for any tail char.
+        String fileContent = "// Tooltip";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        String headerlessContent = parseResult.getContentWithoutHeaderComments();
+        Assert.assertNotNull(headerlessContent);
+        Assert.assertEquals("", headerlessContent);
+    }
+
+    // Exact content of the customer file from TKA-8744.
+    @Test
+    public void pseudoElementsCustomerFile_isFullyStripped() {
+        String fileContent = "//# sourceMappingURL=pseudo-elements.js.map";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        String headerlessContent = parseResult.getContentWithoutHeaderComments();
+        Assert.assertNotNull(headerlessContent);
+        Assert.assertEquals("", headerlessContent);
+    }
+
+    /* --- Header stripping correctness --- */
+
+    @Test
+    public void lineHeaderFollowedByCode_keepsCode() {
+        String fileContent = "// header\nvar x = 1;";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        Assert.assertEquals("var x = 1;", parseResult.getContentWithoutHeaderComments());
+    }
+
+    @Test
+    public void blockHeaderFollowedByCode_keepsCode() {
+        String fileContent = "/* header */\ncode;";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        Assert.assertEquals("code;", parseResult.getContentWithoutHeaderComments());
+    }
+
+    @Test
+    public void stackedLineHeaders_areAllStripped() {
+        String fileContent = "// a\n// b\ncode;";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        Assert.assertEquals("code;", parseResult.getContentWithoutHeaderComments());
+    }
+
+    // Guards against the unanchored String.replace bug: a comment string that
+    // also occurs later in the file must NOT be stripped from that later
+    // occurrence — only the leading header is a "header".
+    @Test
+    public void duplicateHeaderStringInBody_onlyLeadingOccurrenceIsStripped() {
+        String fileContent = "// dup\ncode;\n// dup";
+        ParseResult parseResult = new JavaScriptParser().parse(fileContent);
+        Assert.assertEquals("code;\n// dup", parseResult.getContentWithoutHeaderComments());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JavaScript and HTML file parsing to more robustly strip leading header comments, properly handling edge cases in comment detection and removal while preventing truncation issues.

* **Tests**
  * Added comprehensive unit tests to verify correct header comment removal across various scenarios, including stacked headers, mixed header types, duplicated header patterns, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->