### PR TITLE
SCA-5130: add SOFT_RUN flag to UpdateType

### DIFF
--- a/wss-agent-api/src/main/java/org/whitesource/agent/api/dispatch/UpdateType.java
+++ b/wss-agent-api/src/main/java/org/whitesource/agent/api/dispatch/UpdateType.java
@@ -23,5 +23,6 @@ package org.whitesource.agent.api.dispatch;
 public enum UpdateType {
     OVERRIDE,
     APPEND,
-    REMOVE
+    REMOVE,
+    SOFT_RUN
 }


### PR DESCRIPTION
## Summary
- Adds `SOFT_RUN` to the `UpdateType` enum in `wss-agent-api`.
- Enables the agent to request scans whose results are visible in the Mend platform without updating the project-level state (e.g., `updateType=SOFT_RUN` on `ASYNC_CHECK_POLICY_COMPLIANCE`).
- The matching change in `ws-go-sdk` will be made separately.

Jira: [SCA-5130](https://mend-io.atlassian.net/browse/SCA-5130)

## Test plan
- [ ] `mvn -pl wss-agent-api -am compile` passes (verified locally).
- [ ] Server-side `SOFT_RUN` handling lands and end-to-end scan flow is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCA-5130]: https://mend-io.atlassian.net/browse/SCA-5130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new update type option to the system's update mechanism, providing additional flexibility in how updates are processed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitesource/agents/pull/125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->