### PR TITLE
SCA-5930 Fix intermittent UA UPDATE "Read timed out" by disabling stale connection reuse

### DIFF
--- a/wss-agent-client/src/main/java/org/whitesource/agent/client/WssServiceClientImpl.java
+++ b/wss-agent-client/src/main/java/org/whitesource/agent/client/WssServiceClientImpl.java
@@ -40,6 +40,7 @@ import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.*;
 import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
@@ -187,6 +188,15 @@ public class WssServiceClientImpl implements WssServiceClient {
 
         setConnectionTimeout(this.connectionTimeout);
 
+        // Never reuse a persistent (keep-alive) connection. A pooled connection that an upstream
+        // load balancer / proxy / firewall has silently dropped (half-open) would otherwise be
+        // reused for the next request; the request is then written into a dead socket, no response
+        // ever arrives, and the read blocks for the full connection timeout (default 60 minutes)
+        // before the agent retries on a fresh connection. Forcing a fresh connection per request
+        // removes that "first attempt times out, retry succeeds" failure. The cost is one extra
+        // connection setup per request, which is negligible for the agent's request volume.
+        ((DefaultHttpClient) httpClient).setReuseStrategy(new NoConnectionReuseStrategy());
+
         if (this.proxyEnabled) {
             findDefaultProxy();
         }
@@ -275,7 +285,9 @@ public class WssServiceClientImpl implements WssServiceClient {
         HttpHost proxy = new HttpHost(proxyHost, proxyPort);
         //		httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
         DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
-        httpClient = HttpClients.custom().setRoutePlanner(routePlanner).build();
+        // see constructor: disable connection reuse to avoid reusing a stale/half-open connection
+        httpClient = HttpClients.custom().setRoutePlanner(routePlanner)
+                .setConnectionReuseStrategy(new NoConnectionReuseStrategy()).build();
         logger.info("Using proxy: " + proxy.toHostString());
 
         if (proxyUsername != null && proxyUsername.trim().length() > 0) {
@@ -293,7 +305,8 @@ public class WssServiceClientImpl implements WssServiceClient {
             credsProvider.setCredentials(AuthScope.ANY, credentials);
             // TODO check
             httpClient = HttpClientBuilder.create().setProxy(proxy)
-                    .setDefaultCredentialsProvider(credsProvider).build();
+                    .setDefaultCredentialsProvider(credsProvider)
+                    .setConnectionReuseStrategy(new NoConnectionReuseStrategy()).build();
 
             //            httpClient.getCredentialsProvider().setCredentials(AuthScope.ANY, credentials);
         }


### PR DESCRIPTION
## Summary

Fixes the intermittent **`Failed to send request to WhiteSource server: Unexpected error. Response data is: Read timed out`** that hangs the Unified Agent's first `Sending Update` request for the full connection timeout (default **60 minutes**) before the built-in retry recovers on a fresh connection in seconds.

Jira: **SCA-5930** · Customer evidence: **TKA-10393** (IBM `ibmets`, Cloud Software Group / Citrix SaaS-US — both strategic).

## Root cause

`WssServiceClientImpl` builds its HTTP client with `new DefaultHttpClient()` and **reuses persistent (keep-alive) connections** across every call (orgFlags → checkPolicies → UPDATE → getRequestState), with **no stale-connection check and no idle/TTL eviction**.

When a pooled connection has been silently dropped by an upstream load balancer / proxy / firewall (half-open — no FIN/RST reaches the client), the next request — the large UPDATE POST, issued *after* the minutes-long dependency-resolution phase during which the connection sat idle — is written into a dead socket. No response ever arrives, so the socket read blocks for the entire `wss.connectionTimeoutMinutes` (default 60). The automatic retry opens a **new** connection and the identical payload succeeds in 2–10 s.

This is consistent across all three captured cases:

| Case | Version | UPDATE issued | "Read timed out" | Gap | Retry |
|---|---|---|---|---|---|
| IBM | 26.3.2 / 2.9.9.100 | 11:40:08 UTC | 12:40:10 UTC | **60m02s** | success ~8s |
| Citrix | 26.5.1 | 12:46:50 UTC | 13:46:50 UTC | **60m00s** | success in 2s |
| TensorFlow repro | 26.5.1 | — | — | (laptop-sleep artifact) | success ~10s |

The stack trace confirms the client is blocked in `receiveResponseHeader` with the request already sent. It is **not** a backend-performance issue — the backend processes the same payload in seconds, the failed request never reaches the server (no API_CALL, no CTX), and because the UA exits `SUCCESS(0)` after the retry, the failure is invisible to server telemetry.

## Fix

Disable HTTP connection reuse via `NoConnectionReuseStrategy` on **every** client-creation path so each request uses a fresh connection and a stale/half-open socket can never be reused:

- default constructor (`new DefaultHttpClient()`)
- ignore-certificate constructor
- both `setProxy()` builder paths (reached via `findDefaultProxy()`)

**No timeout semantics are changed**, so legitimately slow large updates are unaffected. The only cost is one extra connection setup (TLS handshake, ~tens of ms) per request — negligible for the agent's handful of requests per scan.

### Why not just raise `wss.connectionTimeoutMinutes`?
The retry already succeeds in seconds, so 60 min is ample; a larger value only makes the *failed* attempt hang **longer**. The correct fix is to never reuse the dead connection in the first place.

## Testing

- `mvn -pl wss-agent-client -am compile` → **BUILD SUCCESS**
- `wss-agent-client` unit tests pass (plus `wss-agent-api`, `wss-agent-utils`).
- The only failing tests are pre-existing SHA-1/MD5 hash assertions in the unrelated `wss-agent-hash-calculator` module, caused by local git CRLF→LF normalization of test fixtures — not touched by and cannot be affected by this change.

## Rollout

This artifact (`wss-agent-api-client`) is consumed by the Unified Agent as a pinned dependency. After release, bump `agent.api.version` in the `unified-agent` `pom.xml` (currently `2.9.9.100`) to the new version and rebuild the Fat JAR.

## Follow-up (separate, not in this PR)
In `setProxy()` the proxy clients are rebuilt *after* `setConnectionTimeout()` runs, so proxied clients currently receive no socket timeout at all. Best fixed by moving timeouts to a per-request `RequestConfig` (works for all client types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP connection handling to avoid reusing persistent connections, which can help reduce connectivity issues in some environments.
  * Updated proxy behavior so connection settings are applied consistently, including when authentication is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->